### PR TITLE
Keep shared test utilities lightweight

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
 - tqdm
 - pip:
     - download
+    - pyarrow

--- a/rpb_tutorial/tutorial_no_drop.py
+++ b/rpb_tutorial/tutorial_no_drop.py
@@ -1,0 +1,194 @@
+"""Tutorial: Extract power-band features without dropping epochs.
+
+This short, beginner-friendly walkthrough demonstrates how to:
+
+1. Load the example EEG epochs file that ships with the regression tests.
+2. Run :func:`mne_features.feature_extraction.extract_features` with
+   ``return_as_df=True`` so that we receive a :class:`pandas.DataFrame`.
+3. Preserve the original epoch numbers in a new ``epoch_id`` column placed at
+   the front of the table.
+4. Validate a small slice of the resulting DataFrame against the ground-truth
+   parquet file used by the automated tests.
+
+Every step is implemented with straightforward, readable Python so you can use
+this script as a starting point for your own experiments.
+"""
+
+from __future__ import annotations
+
+from ast import literal_eval
+from pathlib import Path
+import sys
+from contextlib import contextmanager
+import warnings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+warnings.filterwarnings(
+    "ignore",
+    message="invalid value encountered in divide",
+    category=RuntimeWarning,
+    module="mne_features.univariate",
+)
+
+import mne
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from sklearn.pipeline import FeatureUnion
+
+from mne_features.feature_extraction import extract_features
+
+# ---------------------------------------------------------------------------
+# Locate the shared dataset and regression baseline files that live alongside
+# the automated unit tests.  They are bundled with the repository so this
+# script works out of the box.
+# ---------------------------------------------------------------------------
+DATA_DIR = REPO_ROOT / "unitest"
+EPOCHS_PATH = DATA_DIR / "eeg_clean_epo.fif"
+GROUND_TRUTH_PATH = DATA_DIR / "features_output" / "ground_truth_features.parquet"
+
+# ``extract_features`` expects a frequency-band configuration.  We reuse the
+# same values as the regression tests so the outputs match the stored baseline.
+FREQ_BANDS = {
+    "delta": [0.5, 4.5],
+    "theta": [4.5, 8.5],
+    "alpha": [8.5, 11.5],
+    "sigma": [11.5, 15.5],
+    "beta": [15.5, 30.0],
+}
+FUNCS_PARAMS = {
+    "pow_freq_bands__normalize": False,
+    "pow_freq_bands__ratios": "all",
+    "pow_freq_bands__psd_method": "fft",
+    "pow_freq_bands__freq_bands": FREQ_BANDS,
+}
+
+
+@contextmanager
+def _patched_feature_union():
+    """Convert 1D outputs from ``FeatureUnion`` transformers into row vectors."""
+
+    original_hstack = FeatureUnion._hstack
+
+    def _safe_hstack(self, matrices):
+        reshaped = [
+            matrix.reshape(1, -1)
+            if getattr(matrix, "ndim", 0) == 1
+            else matrix
+            for matrix in matrices
+        ]
+        return original_hstack(self, reshaped)
+
+    FeatureUnion._hstack = _safe_hstack
+    try:
+        yield
+    finally:
+        FeatureUnion._hstack = original_hstack
+
+
+def _ensure_multiindex(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with a simple two-level column :class:`pandas.MultiIndex`."""
+
+    if isinstance(df.columns, pd.MultiIndex):
+        return df
+
+    def _normalise(column):
+        if isinstance(column, tuple):
+            return column
+        if isinstance(column, str):
+            try:
+                parsed = literal_eval(column)
+            except (ValueError, SyntaxError):
+                parsed = None
+            if isinstance(parsed, tuple):
+                return parsed
+        return (column, "")
+
+    result = df.copy()
+    result.columns = pd.MultiIndex.from_tuples([_normalise(col) for col in df.columns])
+    return result
+
+
+
+def main() -> None:
+    """Run the end-to-end extraction pipeline and compare it to the baseline."""
+
+    # ------------------------------------------------------------------
+    # 1. Load the epochs and remember their original indices.  The selection
+    #    array reflects the epoch numbers after any rejects; because we do not
+    #    drop anything here it is simply ``range(len(epochs))``.
+    # ------------------------------------------------------------------
+    epochs = mne.read_epochs(EPOCHS_PATH, preload=True, verbose="ERROR")
+    epoch_ids = epochs.selection.astype(int)
+
+    # ------------------------------------------------------------------
+    # 2. Extract the frequency-band features as a DataFrame.  We copy the
+    #    result so that inserting ``epoch_id`` does not mutate the object that
+    #    ``extract_features`` returned.
+    # ------------------------------------------------------------------
+    with _patched_feature_union():
+        features_df = extract_features(
+            epochs.get_data(),
+            epochs.info["sfreq"],
+            selected_funcs=["pow_freq_bands"],
+            return_as_df=True,
+            funcs_params=FUNCS_PARAMS,
+        ).copy()
+
+    # Ensure the feature names use a two-level MultiIndex so we can insert the
+    # identifier column while keeping a consistent layout.
+    features_df = _ensure_multiindex(features_df)
+
+    features_df.insert(0, ("epoch_id", ""), epoch_ids)
+
+    # ------------------------------------------------------------------
+    # 3. Load the ground-truth DataFrame and align both tables by ``epoch_id``
+    #    so we can perform an easy equality check on a few rows.
+    # ------------------------------------------------------------------
+    ground_truth_df = _ensure_multiindex(
+        pd.read_parquet(GROUND_TRUTH_PATH, engine="pyarrow")
+    )
+
+    extracted_indexed = features_df.set_index(("epoch_id", ""))
+    ground_truth_indexed = ground_truth_df.set_index(("epoch_id", ""))
+    extracted_indexed.index.name = "epoch_id"
+    ground_truth_indexed.index.name = "epoch_id"
+
+    # ------------------------------------------------------------------
+    # 4. Compare a representative subset of epochs and feature columns to
+    #    confirm the freshly extracted values agree with the regression
+    #    baseline.  If the comparison succeeds we print a friendly message for
+    #    the reader.
+    # ------------------------------------------------------------------
+    epoch_subset = [0, 1, 2, 3, 5, 10, 20, 21, 22, 30, 41, 48, 49, 50]
+    shared_columns = [
+        col for col in extracted_indexed.columns if col in ground_truth_indexed.columns
+    ]
+    comparison_columns = shared_columns[:4]  # keep the output compact for the tutorial
+
+    extracted_slice = extracted_indexed.loc[epoch_subset, comparison_columns]
+    baseline_slice = ground_truth_indexed.loc[epoch_subset, comparison_columns]
+
+    try:
+        assert_frame_equal(
+            extracted_slice,
+            baseline_slice,
+            check_exact=False,
+            rtol=1e-12,
+            atol=0.0,
+        )
+    except AssertionError as error:
+        print("❌ Differences detected! Inspect the following tables to investigate.")
+        print(error)
+        print("Extracted slice:\n", extracted_slice)
+        print("Baseline slice:\n", baseline_slice)
+    else:
+        print("✅ Extracted features match the ground truth for the selected epochs.")
+        print("Extracted slice:\n", extracted_slice)
+        print("Ground-truth slice:\n", baseline_slice)
+
+
+if __name__ == "__main__":
+    main()

--- a/rpb_tutorial/tutorial_with_drops.py
+++ b/rpb_tutorial/tutorial_with_drops.py
@@ -1,0 +1,183 @@
+"""Tutorial: Extract features after dropping specific epochs.
+
+This script mirrors the regression test scenario where a few epochs are
+removed before running :func:`mne_features.feature_extraction.extract_features`.
+It guides you through the following steps:
+
+1. Load the bundled EEG epochs and drop a handful of indices.
+2. Extract the frequency-band features and keep a front-facing ``epoch_id``
+   column that records the *original* epoch numbers (not a reindexed range).
+3. Confirm that the resulting values stay perfectly aligned with the official
+   ground-truth DataFrame for a representative subset of epochs.
+
+Run the file directly with ``python tutorial_with_drops.py`` to reproduce the
+entire process.  The code favours clarity over clever tricks so new users can
+follow each step comfortably.
+"""
+
+from __future__ import annotations
+
+from ast import literal_eval
+from pathlib import Path
+import sys
+from contextlib import contextmanager
+import warnings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+warnings.filterwarnings(
+    "ignore",
+    message="invalid value encountered in divide",
+    category=RuntimeWarning,
+    module="mne_features.univariate",
+)
+
+import mne
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from sklearn.pipeline import FeatureUnion
+
+from mne_features.feature_extraction import extract_features
+
+DATA_DIR = REPO_ROOT / "unitest"
+EPOCHS_PATH = DATA_DIR / "eeg_clean_epo.fif"
+GROUND_TRUTH_PATH = DATA_DIR / "features_output" / "ground_truth_features.parquet"
+
+FREQ_BANDS = {
+    "delta": [0.5, 4.5],
+    "theta": [4.5, 8.5],
+    "alpha": [8.5, 11.5],
+    "sigma": [11.5, 15.5],
+    "beta": [15.5, 30.0],
+}
+FUNCS_PARAMS = {
+    "pow_freq_bands__normalize": False,
+    "pow_freq_bands__ratios": "all",
+    "pow_freq_bands__psd_method": "fft",
+    "pow_freq_bands__freq_bands": FREQ_BANDS,
+}
+DROPPED_EPOCHS = [2, 4, 17, 40]
+
+
+@contextmanager
+def _patched_feature_union():
+    """Convert 1D outputs from ``FeatureUnion`` transformers into row vectors."""
+
+    original_hstack = FeatureUnion._hstack
+
+    def _safe_hstack(self, matrices):
+        reshaped = [
+            matrix.reshape(1, -1)
+            if getattr(matrix, "ndim", 0) == 1
+            else matrix
+            for matrix in matrices
+        ]
+        return original_hstack(self, reshaped)
+
+    FeatureUnion._hstack = _safe_hstack
+    try:
+        yield
+    finally:
+        FeatureUnion._hstack = original_hstack
+
+
+def _ensure_multiindex(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with a simple two-level column :class:`pandas.MultiIndex`."""
+
+    if isinstance(df.columns, pd.MultiIndex):
+        return df
+
+    def _normalise(column):
+        if isinstance(column, tuple):
+            return column
+        if isinstance(column, str):
+            try:
+                parsed = literal_eval(column)
+            except (ValueError, SyntaxError):
+                parsed = None
+            if isinstance(parsed, tuple):
+                return parsed
+        return (column, "")
+
+    result = df.copy()
+    result.columns = pd.MultiIndex.from_tuples([_normalise(col) for col in df.columns])
+    return result
+
+
+def main() -> None:
+    """Execute the drop workflow and print a quick validation summary."""
+
+    # ------------------------------------------------------------------
+    # 1. Load the epochs, drop a few entries, and capture the remaining indices.
+    # ------------------------------------------------------------------
+    epochs = mne.read_epochs(EPOCHS_PATH, preload=True, verbose="ERROR")
+    epochs.drop(DROPPED_EPOCHS)
+    epoch_ids = epochs.selection.astype(int)
+
+    # ------------------------------------------------------------------
+    # 2. Extract the features and append the preserved ``epoch_id`` column.
+    # ------------------------------------------------------------------
+    with _patched_feature_union():
+        features_df = extract_features(
+            epochs.get_data(),
+            epochs.info["sfreq"],
+            selected_funcs=["pow_freq_bands"],
+            return_as_df=True,
+            funcs_params=FUNCS_PARAMS,
+        ).copy()
+
+    features_df = _ensure_multiindex(features_df)
+
+    features_df.insert(0, ("epoch_id", ""), epoch_ids)
+
+    # ------------------------------------------------------------------
+    # 3. Align the freshly extracted features with the stored ground truth and
+    #    verify that the remaining epochs still match perfectly.
+    # ------------------------------------------------------------------
+    ground_truth_df = _ensure_multiindex(
+        pd.read_parquet(GROUND_TRUTH_PATH, engine="pyarrow")
+    )
+
+    extracted_indexed = features_df.set_index(("epoch_id", ""))
+    ground_truth_indexed = ground_truth_df.set_index(("epoch_id", ""))
+    extracted_indexed.index.name = "epoch_id"
+    ground_truth_indexed.index.name = "epoch_id"
+
+    expected_epochs = [0, 5, 10, 30, 41, 50]
+    shared_columns = [
+        col for col in extracted_indexed.columns if col in ground_truth_indexed.columns
+    ]
+    comparison_columns = shared_columns[:4]
+
+    extracted_slice = extracted_indexed.loc[expected_epochs, comparison_columns]
+    baseline_slice = ground_truth_indexed.loc[expected_epochs, comparison_columns]
+
+    try:
+        assert_frame_equal(
+            extracted_slice,
+            baseline_slice,
+            check_exact=False,
+            rtol=1e-12,
+            atol=0.0,
+        )
+    except AssertionError as error:
+        print("❌ Differences detected! Check the tables for details.")
+        print(error)
+        print("Extracted slice:\n", extracted_slice)
+        print("Baseline slice:\n", baseline_slice)
+    else:
+        print("✅ Dropped-epoch features still match the ground truth selection.")
+        print("Extracted slice:\n", extracted_slice)
+        print("Ground-truth slice:\n", baseline_slice)
+
+    missing_epochs = set(DROPPED_EPOCHS).intersection(extracted_indexed.index)
+    if missing_epochs:
+        print("⚠️ These dropped epochs unexpectedly remain in the output:", missing_epochs)
+    else:
+        print("🎯 Dropped epochs are absent from the results, as expected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/unitest/test_features_no_drop.py
+++ b/unitest/test_features_no_drop.py
@@ -1,0 +1,56 @@
+import unittest
+
+import pyarrow  # noqa: F401
+from pandas.testing import assert_frame_equal
+
+from unitest import test_utils
+
+
+class TestFeatureExtractionNoDrop(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.epochs = test_utils.load_epochs()
+        cls.features = test_utils.extract_feature_dataframe(cls.epochs)
+        cls.ground_truth = test_utils.load_ground_truth_df()
+        cls.features_indexed = test_utils.to_epoch_indexed(cls.features)
+        cls.ground_truth_indexed = test_utils.to_epoch_indexed(cls.ground_truth)
+        cls.expected_epoch_ids = [0, 5, 10, 30, 41, 50]
+
+    def test_dataframe_integrity_against_ground_truth(self):
+        epoch_column = self.features.columns[0]
+        if isinstance(epoch_column, tuple):
+            self.assertEqual(epoch_column[0], "epoch_id")
+        else:  # pragma: no cover - defensive fallback
+            self.assertEqual(epoch_column, "epoch_id")
+
+        epoch_ids = {int(val) for val in self.features.iloc[:, 0].to_numpy()}
+        for idx in self.expected_epoch_ids:
+            self.assertIn(idx, epoch_ids)
+            self.assertIn(idx, self.features_indexed.index)
+            self.assertIn(idx, self.ground_truth_indexed.index)
+
+        common_columns = [
+            col for col in self.features_indexed.columns if col in self.ground_truth_indexed.columns
+        ]
+        self.assertGreaterEqual(
+            len(common_columns),
+            4,
+            "Expected at least four shared feature columns between extracted data and ground truth.",
+        )
+        ordered_common_columns = sorted(common_columns)
+
+        features_slice = self.features_indexed.loc[
+            self.expected_epoch_ids, ordered_common_columns
+        ].round(9)
+        ground_truth_slice = self.ground_truth_indexed.loc[
+            self.expected_epoch_ids, ordered_common_columns
+        ].round(9)
+        assert_frame_equal(
+            features_slice,
+            ground_truth_slice,
+            check_exact=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitest/test_features_with_drops.py
+++ b/unitest/test_features_with_drops.py
@@ -1,0 +1,61 @@
+import unittest
+
+import pyarrow  # noqa: F401
+from pandas.testing import assert_frame_equal
+
+from unitest import test_utils
+
+
+class TestFeatureExtractionWithDrops(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dropped_indices = [2, 4, 17, 40]
+        base_epochs = test_utils.load_epochs()
+        epochs_with_drops = base_epochs.copy()
+        epochs_with_drops.drop(cls.dropped_indices)
+        cls.features = test_utils.extract_feature_dataframe(epochs_with_drops)
+        cls.ground_truth = test_utils.load_ground_truth_df()
+        cls.features_indexed = test_utils.to_epoch_indexed(cls.features)
+        cls.ground_truth_indexed = test_utils.to_epoch_indexed(cls.ground_truth)
+        cls.expected_epoch_ids = [0, 5, 10, 30, 41, 50]
+
+    def test_dataframe_integrity_after_drops(self):
+        epoch_column = self.features.columns[0]
+        if isinstance(epoch_column, tuple):
+            self.assertEqual(epoch_column[0], "epoch_id")
+        else:  # pragma: no cover - defensive fallback
+            self.assertEqual(epoch_column, "epoch_id")
+
+        epoch_ids = {int(val) for val in self.features.iloc[:, 0].to_numpy()}
+        for idx in self.dropped_indices:
+            self.assertNotIn(idx, epoch_ids)
+        for idx in self.expected_epoch_ids:
+            self.assertIn(idx, epoch_ids)
+            self.assertIn(idx, self.features_indexed.index)
+            self.assertIn(idx, self.ground_truth_indexed.index)
+
+        common_columns = [
+            col for col in self.features_indexed.columns if col in self.ground_truth_indexed.columns
+        ]
+        self.assertGreaterEqual(
+            len(common_columns),
+            4,
+            "Expected at least four shared feature columns between extracted data and ground truth.",
+        )
+        ordered_common_columns = sorted(common_columns)
+
+        features_slice = self.features_indexed.loc[
+            self.expected_epoch_ids, ordered_common_columns
+        ].round(9)
+        ground_truth_slice = self.ground_truth_indexed.loc[
+            self.expected_epoch_ids, ordered_common_columns
+        ].round(9)
+        assert_frame_equal(
+            features_slice,
+            ground_truth_slice,
+            check_exact=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitest/test_utils.py
+++ b/unitest/test_utils.py
@@ -1,0 +1,86 @@
+"""Helper functions dedicated to the regression unit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mne
+import pandas as pd
+
+from mne_features.feature_extraction import extract_features
+
+from .utils import ensure_multiindex, patched_feature_union
+
+DATA_DIR = Path(__file__).resolve().parent
+EPOCHS_PATH = DATA_DIR / "eeg_clean_epo.fif"
+GROUND_TRUTH_PATH = DATA_DIR / "features_output" / "ground_truth_features.parquet"
+
+FREQ_BANDS = {
+    "delta": [0.5, 4.5],
+    "theta": [4.5, 8.5],
+    "alpha": [8.5, 11.5],
+    "sigma": [11.5, 15.5],
+    "beta": [15.5, 30.0],
+}
+
+FUNCS_PARAMS = {
+    "pow_freq_bands__normalize": False,
+    "pow_freq_bands__ratios": "all",
+    "pow_freq_bands__psd_method": "fft",
+    "pow_freq_bands__freq_bands": FREQ_BANDS,
+}
+
+__all__ = [
+    "DATA_DIR",
+    "EPOCHS_PATH",
+    "GROUND_TRUTH_PATH",
+    "extract_feature_dataframe",
+    "load_ground_truth_df",
+    "load_epochs",
+    "to_epoch_indexed",
+]
+
+
+def extract_feature_dataframe(epochs: mne.Epochs) -> pd.DataFrame:
+    """Extract power-band features and prepend the ``epoch_id`` column."""
+
+    epoch_ids = epochs.selection.copy()
+    with patched_feature_union():
+        df = extract_features(
+            epochs.get_data(),
+            epochs.info["sfreq"],
+            selected_funcs=["pow_freq_bands"],
+            return_as_df=True,
+            funcs_params=FUNCS_PARAMS,
+        )
+
+    df = ensure_multiindex(df)
+    df = df.copy()
+    df.insert(0, ("epoch_id", ""), epoch_ids.astype(int))
+    return df
+
+
+def load_ground_truth_df() -> pd.DataFrame:
+    """Load the regression baseline produced by the original pipeline."""
+
+    return ensure_multiindex(pd.read_parquet(GROUND_TRUTH_PATH, engine="pyarrow"))
+
+
+def load_epochs() -> mne.Epochs:
+    """Load the EEG recording used throughout the regression tests."""
+
+    return mne.read_epochs(EPOCHS_PATH, preload=True, verbose="ERROR")
+
+
+def to_epoch_indexed(df: pd.DataFrame, /, *, drop_epoch_column: bool = True) -> pd.DataFrame:
+    """Return ``df`` indexed by the ``epoch_id`` column."""
+
+    normalised = ensure_multiindex(df)
+    result = normalised.copy()
+    epoch_column = result.columns[0]
+    result.set_index(result[epoch_column], inplace=True)
+    result.index.name = "epoch_id"
+    if drop_epoch_column:
+        result.drop(columns=[epoch_column], inplace=True)
+    return result
+

--- a/unitest/utils.py
+++ b/unitest/utils.py
@@ -1,0 +1,75 @@
+"""Shared helpers that are safe to import from tests or tutorials.
+
+This module deliberately exposes only the small collection of utilities that
+both the regression unit tests and the tutorial scripts rely on.  Dataset
+paths, frequency-band configuration, and other test-specific details now live
+in :mod:`unitest.test_utils` so the public helpers here remain lightweight and
+generally applicable.
+"""
+
+from __future__ import annotations
+
+from ast import literal_eval
+from contextlib import contextmanager
+import pandas as pd
+from sklearn.pipeline import FeatureUnion
+
+__all__ = [
+    "ensure_multiindex",
+    "patched_feature_union",
+]
+
+
+@contextmanager
+def patched_feature_union():
+    """Guard :class:`~sklearn.pipeline.FeatureUnion` against 1D outputs."""
+
+    original_hstack = FeatureUnion._hstack
+
+    def _safe_hstack(self, matrices):
+        reshaped = [
+            matrix.reshape(1, -1)
+            if getattr(matrix, "ndim", 0) == 1
+            else matrix
+            for matrix in matrices
+        ]
+        return original_hstack(self, reshaped)
+
+    FeatureUnion._hstack = _safe_hstack
+    try:
+        yield
+    finally:
+        FeatureUnion._hstack = original_hstack
+
+
+def ensure_multiindex(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with a simple two-level column :class:`~pandas.MultiIndex`.
+
+    The regression tests and tutorials both need feature tables whose columns
+    behave like the objects that :mod:`mne_features` ordinarily emits.  Some
+    extraction paths flatten the MultiIndex into plain strings (for example
+    when results are saved to disk and reloaded), so this helper restores the
+    structured column layout in a way that is safe for any caller that expects
+    the canonical two-level shape.  Keeping the utility here ensures the
+    behaviour is shared consistently across tests and user-facing examples.
+    """
+
+    if isinstance(df.columns, pd.MultiIndex):
+        return df
+
+    def _normalise(column):
+        if isinstance(column, tuple):
+            return column
+        if isinstance(column, str):
+            try:
+                parsed = literal_eval(column)
+            except (ValueError, SyntaxError):
+                parsed = None
+            if isinstance(parsed, tuple):
+                return parsed
+        return (column, "")
+
+    result = df.copy()
+    result.columns = pd.MultiIndex.from_tuples([_normalise(col) for col in df.columns])
+    return result
+


### PR DESCRIPTION
## Summary
- remove repository path side effects from `unitest.utils` so it only exposes the shared helper functions
- define the regression dataset paths inside `unitest.test_utils` where they are consumed and re-export them for the tests

## Testing
- python -m unittest unitest.test_features_no_drop unitest.test_features_with_drops

------
https://chatgpt.com/codex/tasks/task_e_68e5a166852083259036c4887163b53f